### PR TITLE
Convert the keys object to list for python3

### DIFF
--- a/WriteFeaturesMarkFDK.py
+++ b/WriteFeaturesMarkFDK.py
@@ -521,7 +521,7 @@ class MarkDataClass(object):
 
 
     def buildLigatureRelatedLines(self, markTypeName):
-        anchorGroupList = self.anchorsDataInLigaturesDict.keys() # ['aboveAR,arAlefMaksura_AlefMaksura', 'aboveAR,arAlefMaksura_AlefMaksura.f', 'aboveAR,arAlefMaksura_AlefMaksura.fj',
+        anchorGroupList = list(self.anchorsDataInLigaturesDict.keys()) # ['aboveAR,arAlefMaksura_AlefMaksura', 'aboveAR,arAlefMaksura_AlefMaksura.f', 'aboveAR,arAlefMaksura_AlefMaksura.fj',
         anchorGroupList.sort()
         ligaturePosLinesList = []
 


### PR DESCRIPTION
Fix the issue where anchorGroupList keys object is sorted before being converted to a list.