### PR TITLE
report() raises ValueError instead of printing, losing the invalid-pair report with it

### DIFF
--- a/kernFeatureWriter.py
+++ b/kernFeatureWriter.py
@@ -677,7 +677,7 @@ class KerningSanitizer(object):
             (self.left_conflict_groups, self.left_glyph_to_group, 'left'),
             (self.right_conflict_groups, self.right_glyph_to_group, 'right')
         ):
-            for group, gl in cg:
+            for group, gl in cg.items():
                 print(
                     f'group {group} ignored because it contains glyph {gl} '
                     f'double-mapped on {desc} side (other group is {g2g[gl]})')


### PR DESCRIPTION
`report()` unpacks two values per item out of a dict, so it raises instead of printing the
diagnostic it exists for.

```python
for cg, g2g, desc in (
    (self.left_conflict_groups, self.left_glyph_to_group, 'left'),
    (self.right_conflict_groups, self.right_glyph_to_group, 'right')
):
    for group, gl in cg:      # cg is a dict -> yields '@MMK_L_TWO' -> ValueError
```

`left_conflict_groups` / `right_conflict_groups` are initialised as `{}` (lines 595, 597) and
populated as `cg[g] = gl` (line 626). Iterating a dict yields its keys, so unpacking each into
`group, gl` fails as soon as a group name is longer than two characters:

```
ValueError: too many values to unpack (expected 2)
```

**Two diagnostics are lost, not one.** The conflict-group notice — the only warning that a kerning
group was silently discarded — never prints. And because `report()` is a single call with no
`try`, the exception also kills the `invalid_pairs` loop that follows it. Since the discarded group
is exactly what makes its pairs invalid, both halves of the explanation disappear, and the run
aborts with a traceback before `kern.fea` is written.

**Why it usually goes unnoticed:** the path needs a glyph mapped into two kerning groups on the
same side, and `fontTools.ufoLib` refuses to save that under `public.kern1.*` / `public.kern2.*`
names (`UFOLibError: The glyph "B" occurs in too many kerning groups.`). It stays reachable
through legacy `@MMK_L_` / `@MMK_R_` groups, which `is_kerning_group()` accepts (line 81) and
ufoLib does not validate.

## Reproduction

```python
import defcon

f = defcon.Font()
for n in ('A', 'B', 'C'):
    f.newGlyph(n).width = 500

f.groups['@MMK_L_ONE'] = ['A', 'B']       # B double-mapped on the left side
f.groups['@MMK_L_TWO'] = ['B', 'C']
f.groups['@MMK_R_RIGHT'] = ['A', 'C']

f.kerning[('@MMK_L_ONE', '@MMK_R_RIGHT')] = -50
f.kerning[('@MMK_L_TWO', '@MMK_R_RIGHT')] = -30
f.save('Repro.ufo')
```

`python kernFeatureWriter.py Repro.ufo` writes no `kern.fea` and exits 1 with the traceback above.
(Using `public.kern1.*` names instead fails earlier, at `f.save()`, with the ufoLib error — which
is why the fixture uses `@MMK_` names.)

With this change both suppressed lines print and `kern.fea` is written with the surviving pair:

```
group @MMK_L_TWO ignored because it contains glyph B double-mapped on left side (other group is @MMK_L_ONE)
pair (@MMK_L_TWO @MMK_R_RIGHT) references invalid group @MMK_L_TWO
```

The drop itself is correct behaviour and is unchanged — this only restores the report that
explains it.

Line numbers are at `503b206`.